### PR TITLE
Vehicle Inventory Workaround (the Jackpot list...)

### DIFF
--- a/Client/Functions/Client_OnPurchaseOrderReceived.sqf
+++ b/Client/Functions/Client_OnPurchaseOrderReceived.sqf
@@ -166,7 +166,8 @@ if (_model isKindOf "Man") then {
 	player reveal _vehicle;
 
 	//--- Authorize the air loadout depending on the parameters set
-	if (_vehicle isKindOf "Air") then {[_vehicle, CTI_P_SideJoined] call CTI_CO_FNC_SanitizeAircraft};
+	if (_vehicle isKindOf "Air") then {[_vehicle, CTI_P_SideJoined] call CTI_CO_FNC_SanitizeAircraft;};
+	if (_vehicle isKindOf "LandVehicle") then { [_vehicle, CTI_P_SideJoined] call CTI_CO_FNC_SanitizeLandVehicle;};
 
 	//--- Sanitize the artillery loadout, mines may lag the server for instance
 	if (CTI_ARTILLERY_FILTER == 1) then {if (_model in (missionNamespace getVariable ["CTI_ARTILLERY", []])) then {(_vehicle) call CTI_CO_FNC_SanitizeArtillery}};

--- a/Common/Functions/Common_SanitizeLandVehicle.sqf
+++ b/Common/Functions/Common_SanitizeLandVehicle.sqf
@@ -26,11 +26,14 @@
     -> Sanitize the player's vehicle depending on the upgrade levels/parameters
 */
 
-private ["_side","_vehicle","_cargo","_items","_toDelete","_index"];
+// Test with debug console: CTI_CO_FNC_SanitizeLandVehicle = compile preprocessFileLineNumbers "Common\Functions\Common_SanitizeLandVehicle.sqf"; [cursorTarget] call CTI_CO_FNC_SanitizeLandVehicle;
+
+private ["_vehicle","_cargo","_items","_forbidden","_i","_oldItem","_newItem","_newCount","_foundItemsToReplace","_replacements"];
 
 _vehicle = _this select 0;
-_side = _this select 1;
+// _side = _this select 1;
 
+// these will be cleared from any vehicle purchased.
 _forbidden = [
     "rhs_rpg7_PG7VR_mag",
     "rhs_rpg7_PG7VL_mag",
@@ -45,7 +48,14 @@ _forbidden = [
     "rhs_fgm148_magazine_AT"
 ];
 
-systemChat "Sanitizing Vehicle";
+//each of these items will be replaces by the new item at the count
+// ["oldItem", "newItem", count]
+_replacements = [
+  ["rhs_weap_fgm148", "rhs_weap_M136_hp", 4],
+  ["rhs_weap_rpg7", "rhs_weap_rpg26", 4]
+];
+
+diag_log "Sanitizing vehicle";
 
 _cargo = _vehicle call CTI_UI_Gear_GetUnitEquipment;
 
@@ -58,23 +68,28 @@ _cargo = _vehicle call CTI_UI_Gear_GetUnitEquipment;
 
 _items = _cargo select 1 select 2 select 1;
 
-//remove disallowed items
-_index = 0;
-_toDelete = [];
-{
-  // if ([disallowed].indexOf(_x[0]) > -1) {}
-  if ((_forbidden find (_x select 0)) > -1) then {
-    systemChat format ["deleting %1", _index];
-    _toDelete = _toDelete + [_index];
-  };
-  _index = _index + 1;
-} forEach _items;
+//remove forbidden
+_items = _items - _forbidden;
 
+//for each replacement item
 {
-  _items set [_x, -1];
-} forEach _toDelete;
+  _oldItem = _x select 0;
+  _newItem = _x select 1;
+  _newCount = _x select 2;
 
-_items = _items - [-1];
+  _foundItemsToReplace = { _x == _oldItem } count _items;
+
+  _newCount = _newCount * _foundItemsToReplace;
+
+  _items = _items - [_oldItem];
+
+  _i = 0;
+  while { _i < _newCount }
+  do {
+    _items pushBack _newItem;
+    _i = _i + 1;
+  }
+} forEach _replacements;
 
 // set the new _items value back in the unit equipment structure
 _cargo select 1 select 2 set [1, _items];

--- a/Common/Functions/Common_SanitizeLandVehicle.sqf
+++ b/Common/Functions/Common_SanitizeLandVehicle.sqf
@@ -1,0 +1,82 @@
+/*
+  # HEADER #
+  Script: 		Common\Functions\Common_SanitizeLandVehicle.sqf
+  Alias:			CTI_CO_FNC_SanitizeLandVehicle
+  Description:	Sanitize the equipment of trucks and tanks
+  Author: 	   donald.mull@gmail.com
+  Creation Date:	20-05-2015
+  Revision Date:
+
+  # PARAMETERS #
+    0	[Object]: The vehicle
+    1	[Side]: The side of the vehicle
+
+  # RETURNED VALUE #
+  None
+
+  # SYNTAX #
+  [VEHICLE, SIDE] call CTI_CO_FNC_SanitizeLandVehicle
+
+  # DEPENDENCIES #
+  Common Function: CTI_UI_Gear_GetUnitEquipment
+  Common Function: CTI_CO_FNC_EquipUnit
+
+  # EXAMPLE #
+    [vehicle player, CTI_P_SideJoined] call CTI_CO_FNC_SanitizeLandVehicle;
+    -> Sanitize the player's vehicle depending on the upgrade levels/parameters
+*/
+
+private ["_side","_vehicle","_cargo","_items","_toDelete","_index"];
+
+_vehicle = _this select 0;
+_side = _this select 1;
+
+_forbidden = [
+    "rhs_rpg7_PG7VR_mag",
+    "rhs_rpg7_PG7VL_mag",
+    "rhs_rpg7_OG7V_mag",
+    "rhs_rpg7_TBG7V_mag",
+    "rhs_rpg26_mag",
+    "rhs_rshg2_mag",
+    "rhs_rpg18_mag",
+    "rhs_m136_hedp_mag",
+    "rhs_m136_hp_mag",
+    "rhs_m136_mag",
+    "rhs_fgm148_magazine_AT"
+];
+
+systemChat "Sanitizing Vehicle";
+
+_cargo = _vehicle call CTI_UI_Gear_GetUnitEquipment;
+
+/*We want the backpack from _cargo in format:
+ [["",[],[]], ["",[],[]], ["",[],[]]],
+ [["",[]], ["",[]],["backpack",[]]],
+ ["",""],
+ [["", ""], ["", "", "", "", ""]]
+*/
+
+_items = _cargo select 1 select 2 select 1;
+
+//remove disallowed items
+_index = 0;
+_toDelete = [];
+{
+  // if ([disallowed].indexOf(_x[0]) > -1) {}
+  if ((_forbidden find (_x select 0)) > -1) then {
+    systemChat format ["deleting %1", _index];
+    _toDelete = _toDelete + [_index];
+  };
+  _index = _index + 1;
+} forEach _items;
+
+{
+  _items set [_x, -1];
+} forEach _toDelete;
+
+_items = _items - [-1];
+
+// set the new _items value back in the unit equipment structure
+_cargo select 1 select 2 set [1, _items];
+
+[_vehicle, _cargo] call CTI_CO_FNC_EquipUnit;

--- a/Common/Init/Init_Common.sqf
+++ b/Common/Init/Init_Common.sqf
@@ -79,6 +79,7 @@ CTI_CO_FNC_SanitizeAircraftAT = compileFinal preprocessFileLineNumbers "Common\F
 CTI_CO_FNC_SanitizeAircraftCM = compileFinal preprocessFileLineNumbers "Common\Functions\Common_SanitizeAircraftCM.sqf";
 CTI_CO_FNC_SanitizeAircraftFFAR = compileFinal preprocessFileLineNumbers "Common\Functions\Common_SanitizeAircraftFFAR.sqf";
 CTI_CO_FNC_SanitizeArtillery = compileFinal preprocessFileLineNumbers "Common\Functions\Common_SanitizeArtillery.sqf";
+CTI_CO_FNC_SanitizeLandVehicle = compileFinal preprocessFileLineNumbers "Common\Functions\Common_SanitizeLandVehicle.sqf";
 CTI_CO_FNC_GetRandomSkill = compileFinal preprocessFileLineNumbers "Addons\AiRandomSkill\RandomSkill.sqf";
 
 

--- a/Server/Functions/Server_HandleAIPurchase.sqf
+++ b/Server/Functions/Server_HandleAIPurchase.sqf
@@ -6,7 +6,7 @@
 	Author: 		Benny
 	Creation Date:	20-09-2013
 	Revision Date:	20-09-2013
-	
+
   # PARAMETERS #
     0	[Number]: The purchase seed
     1	[String]: The purchased unit classname
@@ -14,13 +14,13 @@
     3	[Group]: The group the unit shall belong to
     4	[Object]: The factory
     5	[Side]: The side of the unit
-	
+
   # RETURNED VALUE #
 	None
-	
+
   # SYNTAX #
 	[PURCHASE SEED, UNIT CLASSNAME, BUYER, TARGET, FACTORY, SIDE] spawn CTI_SE_FNC_HandleAIPurchase
-	
+
   # DEPENDENCIES #
 	Common Function: CTI_CO_FNC_ChangeFunds
 	Common Function: CTI_CO_FNC_CreateUnit
@@ -33,7 +33,7 @@
 	Common Function: CTI_CO_FNC_SanitizeAircraft
 	Server Function: CTI_SE_FNC_HandleEmptyVehicle
 	Server Function: CTI_SE_FNC_OnClientPurchaseComplete
-	
+
   # EXAMPLE #
     [_req_seed, _req_classname, _req_buyer, _req_target, _factory, _req_side] spawn CTI_SE_FNC_HandleAIPurchase;
 */
@@ -67,7 +67,7 @@ _cost = _var_classname select 2;
 if !(_model isKindOf "Man") then { //--- Add the vehicle crew cost if applicable
 	_crew = switch (true) do { case (_model isKindOf "Tank"): {"Crew"}; case (_model isKindOf "Air"): {"Pilot"}; default {"Soldier"}};
 	_crew = missionNamespace getVariable format["CTI_%1_%2", _req_side, _crew];
-	
+
 	_var_crew_classname = missionNamespace getVariable _crew;
 	if !(isNil '_var_crew_classname') then { _cost = _cost + ((count(_model call CTI_CO_FNC_GetVehicleTurrets)+1) * (_var_crew_classname select 2)) };
 };
@@ -106,22 +106,24 @@ if (_model isKindOf "Man") then {
 } else {
 	private ["_crew", "_unit"];
 	_vehicle = [_model, _position, _direction + getDir _factory, _sideID, true, true, true] call CTI_CO_FNC_CreateVehicle;
-	
+
 	_crew = switch (true) do { case (_model isKindOf "Tank"): {"Crew"}; case (_model isKindOf "Air"): {"Pilot"}; default {"Soldier"}};
 	_crew = missionNamespace getVariable format["CTI_%1_%2", _req_side, _crew];
-	
+
 	_unit = [_crew, _req_target, _position, _sideID, _net] call CTI_CO_FNC_CreateUnit;
 	_unit moveInDriver _vehicle;
-	
+
 	{
 		_unit = [_crew, _req_target, _position, _sideID, _net] call CTI_CO_FNC_CreateUnit;
 		_unit moveInTurret [_vehicle, _x];
 	} forEach (_model call CTI_CO_FNC_GetVehicleTurrets);
 
 	[_vehicle] spawn CTI_SE_FNC_HandleEmptyVehicle;
-	
+
 	//--- Authorize the air loadout depending on the parameters set
 	if (_vehicle isKindOf "Air") then {[_vehicle, _req_side] call CTI_CO_FNC_SanitizeAircraft};
+	systemChat format ["type %1", typeOf _vehicle];
+ 	if (_vehicle isKindOf "LandVehicle") then {[_vehicle, _req_side] call CTI_CO_FNC_SanitizeLandVehicle};
 	// _req_target addVehicle _vehicle;
 };
 

--- a/Server/Functions/Server_HandleAIPurchase.sqf
+++ b/Server/Functions/Server_HandleAIPurchase.sqf
@@ -6,7 +6,7 @@
 	Author: 		Benny
 	Creation Date:	20-09-2013
 	Revision Date:	20-09-2013
-
+	
   # PARAMETERS #
     0	[Number]: The purchase seed
     1	[String]: The purchased unit classname
@@ -14,13 +14,13 @@
     3	[Group]: The group the unit shall belong to
     4	[Object]: The factory
     5	[Side]: The side of the unit
-
+	
   # RETURNED VALUE #
 	None
-
+	
   # SYNTAX #
 	[PURCHASE SEED, UNIT CLASSNAME, BUYER, TARGET, FACTORY, SIDE] spawn CTI_SE_FNC_HandleAIPurchase
-
+	
   # DEPENDENCIES #
 	Common Function: CTI_CO_FNC_ChangeFunds
 	Common Function: CTI_CO_FNC_CreateUnit
@@ -33,7 +33,7 @@
 	Common Function: CTI_CO_FNC_SanitizeAircraft
 	Server Function: CTI_SE_FNC_HandleEmptyVehicle
 	Server Function: CTI_SE_FNC_OnClientPurchaseComplete
-
+	
   # EXAMPLE #
     [_req_seed, _req_classname, _req_buyer, _req_target, _factory, _req_side] spawn CTI_SE_FNC_HandleAIPurchase;
 */
@@ -67,7 +67,7 @@ _cost = _var_classname select 2;
 if !(_model isKindOf "Man") then { //--- Add the vehicle crew cost if applicable
 	_crew = switch (true) do { case (_model isKindOf "Tank"): {"Crew"}; case (_model isKindOf "Air"): {"Pilot"}; default {"Soldier"}};
 	_crew = missionNamespace getVariable format["CTI_%1_%2", _req_side, _crew];
-
+	
 	_var_crew_classname = missionNamespace getVariable _crew;
 	if !(isNil '_var_crew_classname') then { _cost = _cost + ((count(_model call CTI_CO_FNC_GetVehicleTurrets)+1) * (_var_crew_classname select 2)) };
 };
@@ -101,29 +101,28 @@ if (_funds < _cost) exitWith { [_req_seed, _req_classname, _req_target, _factory
 if (typeName _req_target == "SIDE") then { _req_target = createGroup _req_side };
 
 _vehicle = objNull;
-diag_log format ["type %1", typeOf _model];
 if (_model isKindOf "Man") then {
 	_vehicle = [_model, _req_target, _position, _sideID, _net] call CTI_CO_FNC_CreateUnit;
 } else {
 	private ["_crew", "_unit"];
 	_vehicle = [_model, _position, _direction + getDir _factory, _sideID, true, true, true] call CTI_CO_FNC_CreateVehicle;
-
+	
 	_crew = switch (true) do { case (_model isKindOf "Tank"): {"Crew"}; case (_model isKindOf "Air"): {"Pilot"}; default {"Soldier"}};
 	_crew = missionNamespace getVariable format["CTI_%1_%2", _req_side, _crew];
-
+	
 	_unit = [_crew, _req_target, _position, _sideID, _net] call CTI_CO_FNC_CreateUnit;
 	_unit moveInDriver _vehicle;
-
+	
 	{
 		_unit = [_crew, _req_target, _position, _sideID, _net] call CTI_CO_FNC_CreateUnit;
 		_unit moveInTurret [_vehicle, _x];
 	} forEach (_model call CTI_CO_FNC_GetVehicleTurrets);
 
 	[_vehicle] spawn CTI_SE_FNC_HandleEmptyVehicle;
-
+	
 	//--- Authorize the air loadout depending on the parameters set
-	if (_vehicle isKindOf "Air") then {[_vehicle, _req_side] call CTI_CO_FNC_SanitizeAircraft;};
- 	if (_vehicle isKindOf "LandVehicle") then {[_vehicle, _req_side] call CTI_CO_FNC_SanitizeLandVehicle;};
+	if (_vehicle isKindOf "Air") then {[_vehicle, _req_side] call CTI_CO_FNC_SanitizeAircraft};
+	if (_vehicle isKindOf "LandVehicle") then {[_vehicle, _req_side] call CTI_CO_FNC_SanitizeLandVehicle;};
 	// _req_target addVehicle _vehicle;
 };
 

--- a/Server/Functions/Server_HandleAIPurchase.sqf
+++ b/Server/Functions/Server_HandleAIPurchase.sqf
@@ -101,6 +101,7 @@ if (_funds < _cost) exitWith { [_req_seed, _req_classname, _req_target, _factory
 if (typeName _req_target == "SIDE") then { _req_target = createGroup _req_side };
 
 _vehicle = objNull;
+diag_log format ["type %1", typeOf _model];
 if (_model isKindOf "Man") then {
 	_vehicle = [_model, _req_target, _position, _sideID, _net] call CTI_CO_FNC_CreateUnit;
 } else {
@@ -121,9 +122,8 @@ if (_model isKindOf "Man") then {
 	[_vehicle] spawn CTI_SE_FNC_HandleEmptyVehicle;
 
 	//--- Authorize the air loadout depending on the parameters set
-	if (_vehicle isKindOf "Air") then {[_vehicle, _req_side] call CTI_CO_FNC_SanitizeAircraft};
-	systemChat format ["type %1", typeOf _vehicle];
- 	if (_vehicle isKindOf "LandVehicle") then {[_vehicle, _req_side] call CTI_CO_FNC_SanitizeLandVehicle};
+	if (_vehicle isKindOf "Air") then {[_vehicle, _req_side] call CTI_CO_FNC_SanitizeAircraft;};
+ 	if (_vehicle isKindOf "LandVehicle") then {[_vehicle, _req_side] call CTI_CO_FNC_SanitizeLandVehicle;};
 	// _req_target addVehicle _vehicle;
 };
 


### PR DESCRIPTION
Originally #1.
Delete all instances of:
rhs_rpg7_PG7VR_mag
rhs_rpg7_PG7VL_mag
rhs_rpg7_OG7V_mag
rhs_rpg7_TBG7V_mag
rhs_rpg26_mag
rhs_rshg2_mag
rhs_rpg18_mag
rhs_m136_hedp_mag
rhs_m136_hp_mag
rhs_m136_mag
rhs_fgm148_magazine_AT

Replace "rhs_weap_fgm148" with "rhs_weap_M136_hp" x4

Replace "rhs_weap_rpg7" with "rhs_weap_rpg26" x4
